### PR TITLE
Add "DNE" to GymExperiment

### DIFF
--- a/experiments/acrobot.rb
+++ b/experiments/acrobot.rb
@@ -20,7 +20,7 @@ config = {
   }
 }
 
-exp = GymExperiment.new config
+exp = DNE::GymExperiment.new config
 exp.run
 puts "Re-running best individual "
 exp.show_best


### PR DESCRIPTION
Apologies for not opening an issue first, but this seemed to be a small fix. Ruby is not my area of expertise so hopefully I don't misunderstand the problem.

I get the following error running the Acrobot experiment (with `bundle exec ruby experiments/acrobot.rb`) as-is:

```
experiments/acrobot.rb:23:in `<main>': uninitialized constant GymExperiment (NameError)
```

Changing that line to add a `DNE::` prefix to `GymExperiment` removes this error.