### PR TITLE
Add instructions for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The algorithms themselves are coded in the [`machine_learning_workbench` library
 First make sure the OpenAI Gym is pip-installed on python3, [instructions here](https://github.com/openai/gym).  
 You will also need the [GVGAI_GYM](https://github.com/rubenrtorrado/GVGAI_GYM) to access GVGAI environments.
 
+Mac users will need to tell the numo-linalg library where BLAS is:
+
+    $ gem install numo-linalg -- --with-openblas-dir=/usr/local/opt/openblas
+
+(per @sonot's [gist](https://gist.github.com/sonots/6fadc6cbbb170b9c4a0c9396c91a88e1))
+
 Clone this repository, then execute:
 
     $ bundle install

--- a/experiments/acrobot.rb
+++ b/experiments/acrobot.rb
@@ -20,7 +20,7 @@ config = {
   }
 }
 
-exp = GymExperiment.new config
+exp = DNE::GymExperiment.new config
 exp.run
 puts "Re-running best individual "
 exp.show_best


### PR DESCRIPTION
I was unable to get this running on Mac until I ran the command (`gem install numo-linalg -- --with-openblas-dir=/usr/local/opt/openblas`). I believe this will be a general issue for users on OSX so I added it to the README.